### PR TITLE
Prep for 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
+## 1.1.1
+* Fixes "monkey before sending request" (#2)
+* Fix 1-in-10 bug (#6)
+
 ## 1.1.0
 * Clarify README
 * Tone down Log.e to Log.w
 * Turn wifi back on after 5 seconds (#4)
 * Update AGP, Gradle, compileSdk, targetSdk, OkHttp
-* Fixes "monkey before sending request" (#2)
-* Fix 1-in-10 bug (#6)
 
 ## 1.0.2
 * Remove dependency on support lib

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Download via Maven:
 <dependency>
   <groupId>io.jasonatwood</groupId>
   <artifactId>networkmonkey</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <type>pom</type>
 </dependency>
 ```
@@ -141,7 +141,7 @@ Download via Maven:
 or Gradle:
 
 ```groovy
-compile 'io.jasonatwood:networkmonkey:1.1.0'
+compile 'io.jasonatwood:networkmonkey:1.1.1'
 ```
 
 Network Monkey requires at minimum Android API 14.

--- a/networkmonkey/build.gradle
+++ b/networkmonkey/build.gradle
@@ -15,8 +15,8 @@ ext {
     siteUrl = 'https://github.com/tir38/android-network-monkey'
     gitUrl = 'https://github.com/tir38/android-network-monkey.git'
 
-    libraryVersion = '1.1.0'
-    libraryVersionCode = 4
+    libraryVersion = '1.1.1'
+    libraryVersionCode = 5
 
     developerId = 'jasonatwood'
     developerName = 'Jason Atwood'


### PR DESCRIPTION
I didn't actually get fixes for #2 and #6 into the 1.1.0 build (git merge error) . So I need to release 1.1.1 to get those out.